### PR TITLE
Use Altered Directory Structure to Store Name Files

### DIFF
--- a/bbqs_master/bin/build_bed_names.py
+++ b/bbqs_master/bin/build_bed_names.py
@@ -29,6 +29,21 @@ def build_names(bed_data, strain):
     return names
 
 
+def write_names(fn, strain, names, label, method):
+
+    names = gff.partition_sequences(names)
+
+    for seq_id in names:
+        with open(f"data/tracks/{strain}/{label}/{seq_id}/{fn}", method) as f:
+            for line in names[seq_id]:
+                search = '","'.join(line[0])
+                other = '","'.join(line[1:])
+                out_string=f'[["{search}"],"{other}"]\n'
+                f.write(out_string)
+
+    return
+
+
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(
         description='Build a names text file from a gff file.')
@@ -38,8 +53,10 @@ if __name__ == "__main__":
                         help='the name of the names file to write. NOTE: This should not be the full path and this program will prepend "data/tracks/strain/seq_id/" to the chosen name (default: %(default)s)')
     parser.add_argument('--strain', "-s", type=str, required=False, default="BBQS859",
                         help='the strain on which we are operating (default: %(default)s)')
+    parser.add_argument('--label', '-l', type=str, required=True,
+                        help='the track label for the names being built. Required.')
 
     args = vars(parser.parse_args())
     bed_data = bed.read_bed(args["in"])
     names = build_names(bed_data, args["strain"])
-    gff.write_names(args["out"], args["strain"], names, "a")
+    write_names(args["out"], args["strain"], names, args['label'], "w")

--- a/bbqs_master/bin/build_gff_names.py
+++ b/bbqs_master/bin/build_gff_names.py
@@ -84,12 +84,12 @@ def partition_sequences(names):
     return sequences
 
 
-def write_names(fn, strain, names, method):
+def write_names(fn, strain, names, label, method):
 
     names = partition_sequences(names)
 
     for seq_id in names:
-        with open(f"data/tracks/{strain}/{seq_id}/{fn}", method) as f:
+        with open(f"data/tracks/{strain}/{label}/{seq_id}/{fn}", method) as f:
             for line in names[seq_id]:
                 search = '","'.join(line[0])
                 other = '","'.join(line[1:])
@@ -108,8 +108,10 @@ if __name__ == "__main__":
                         help='the name of the names file to write. NOTE: This should not be the full path and this program will prepend "data/tracks/strain/seq_id/" to the chosen name (default: %(default)s)')
     parser.add_argument('--strain', "-s", type=str, required=False, default="BBQS859",
                         help='the strain on which we are operating (default: %(default)s)')
+    parser.add_argument('--label', '-l', type=str, required=False, default='Prokka',
+                        help='the track label for the names being built. (default: %(default)s)')
 
     args = vars(parser.parse_args())
     gff = parse_gff(args["in"])
     names = build_names(gff, args["strain"])
-    write_names(args["out"], args["strain"], names, "w")
+    write_names(args["out"], args["strain"], names, args['label'], "w")

--- a/bbqs_master/src/JBrowse/View/Dialog/Search.js
+++ b/bbqs_master/src/JBrowse/View/Dialog/Search.js
@@ -140,17 +140,19 @@ function (
                                         locstring: Util.assembleLocString(elt.multipleLocations[j]),
                                         location: elt.multipleLocations[j],
                                         label: elt.name,
-                                        description: track.label || track.key || defaultTrack.label || defaultTrack.key || 'Unknown track',
+                                        description: track.label || track.key || defaultTrack.key || defaultTrack.label || 'Unknown track',
                                         tracks: track
                                     });
                                 }
                             } else {
                                 var track = (elt.location.tracks||[]).length ? elt.location.tracks[0] : {};
+                                console.log(elt)
+                                console.log(track)
                                 grid.push({
                                     locstring: Util.assembleLocString(elt.location),
                                     location: elt.location,
                                     label: elt.location.objectName,
-                                    description: track.label || track.key || defaultTrack.label || defaultTrack.key || 'Unknown track',
+                                    description: track.label || track.key || defaultTrack.key || defaultTrack.label || 'Unknown track',
                                     tracks: track
                                 });
                             }


### PR DESCRIPTION
To build its search database, you must run the `generate-names.pl` script which
indexes the names that will become searchable. Names were previously stored in
a large `names.txt` file, but this change makes it easier to separate out these
names by track in a way that is acceptable to the original perl script. In the
future, this will hopefully allow a more useful feature description in the search
window.


